### PR TITLE
Blocking Operation of Single Shot Measurement Now Optional

### DIFF
--- a/src/SensirionI2CScd4x.cpp
+++ b/src/SensirionI2CScd4x.cpp
@@ -588,7 +588,7 @@ uint16_t SensirionI2CScd4x::reinit() {
     return error;
 }
 
-uint16_t SensirionI2CScd4x::measureSingleShot() {
+uint16_t SensirionI2CScd4x::measureSingleShot(bool blocking) {
     uint16_t error;
     uint8_t buffer[2];
     SensirionI2CTxFrame txFrame(buffer, 2);
@@ -600,7 +600,11 @@ uint16_t SensirionI2CScd4x::measureSingleShot() {
 
     error = SensirionI2CCommunication::sendFrame(SCD4X_I2C_ADDRESS, txFrame,
                                                  *_i2cBus);
-    delay(5000);
+
+    if (blocking) {
+        delay(5000);
+    }
+
     return error;
 }
 

--- a/src/SensirionI2CScd4x.h
+++ b/src/SensirionI2CScd4x.h
@@ -400,11 +400,13 @@ class SensirionI2CScd4x {
      * relative humidity and temperature. The sensor output is read with the
      * read_measurement command.
      *
+     * @param blocking Delay for 5 seconds till on-demand measurement is available
+     *
      * @note Only available in idle mode.
      *
      * @return 0 on success, an error code otherwise
      */
-    uint16_t measureSingleShot(void);
+    uint16_t measureSingleShot(bool blocking = true);
 
     /**
      * measureSingleShotRhtOnly() - On-demand measurement of relative humidity


### PR DESCRIPTION
Hello,

it is very inconvenient that this library enforces a 5 sec. blocking delay when performing a single shot measurement.

It is understood that you need to wait for 5 sec. till the measurement results are available, but this can be done in the calling application in a non-blocking fashion.

I've therefore added a parameter which allows non-blocking operation of the single shot measurement method with blocking mode being the default - so no behavior change for existent applications.

Best regards
Andreas