### PR TITLE
Update github_release workflow

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -8,3 +8,4 @@ on:
 jobs:
   github-release:
     uses: sensirion/.github/.github/workflows/driver.common.github_release.yml@main
+    secrets: inherit


### PR DESCRIPTION
Secrets are not passed to reusable workflows by default